### PR TITLE
Fix usage of open()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(os.path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
+with io.open(os.path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
When trying to pip install (Python 2.7), I got the following error:

pip install asq
Collecting asq
  Downloading asq-1.2.tar.gz (43kB)
    100% |████████████████████████████████| 45kB 406kB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/var/folders/l6/h93q_nl56b57smmxbs8qwpyw0000gn/T/pip-build-s5t9M7/asq/setup.py", line 27, in <module>
        with open(os.path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
    TypeError: 'encoding' is an invalid keyword argument for this function

Please merge.
TIA,
Dror