### PR TITLE
Fixed some deprecation warnings in test suite

### DIFF
--- a/asq/test/test_group_by.py
+++ b/asq/test/test_group_by.py
@@ -13,9 +13,9 @@ class TestGroupBy(unittest.TestCase):
         g1 = b[0]
         g2 = b[1]
         g3 = b[2]
-        self.assert_(isinstance(g1, Grouping))
-        self.assert_(isinstance(g2, Grouping))
-        self.assert_(isinstance(g3, Grouping))
+        self.assertIsInstance(g1, Grouping)
+        self.assertIsInstance(g2, Grouping)
+        self.assertIsInstance(g3, Grouping)
         self.assertEqual(g1.to_list(), ['Agapanthus', 'Allium', 'Alpina', 'Alstroemeria', 'Amaranthus', 'Amarylis'])
         self.assertEqual(g2.to_list(), ['Bouvardia'])
         self.assertEqual(g3.to_list(), ['Carnations', 'Cattleya', 'Celosia', 'Chincherinchee', 'Chrysanthemum'])
@@ -34,9 +34,9 @@ class TestGroupBy(unittest.TestCase):
         g1 = b[0]
         g2 = b[1]
         g3 = b[2]
-        self.assert_(isinstance(g1, Grouping))
-        self.assert_(isinstance(g2, Grouping))
-        self.assert_(isinstance(g3, Grouping))
+        self.assertIsInstance(g1, Grouping)
+        self.assertIsInstance(g2, Grouping)
+        self.assertIsInstance(g3, Grouping)
         self.assertEqual(g1.to_list(), ['agapanthus', 'allium', 'alpina', 'alstroemeria', 'amaranthus', 'amarylis'])
         self.assertEqual(g2.to_list(), ['bouvardia'])
         self.assertEqual(g3.to_list(), ['carnations', 'cattleya', 'celosia', 'chincherinchee', 'chrysanthemum'])

--- a/asq/test/test_to_lookup.py
+++ b/asq/test/test_to_lookup.py
@@ -13,9 +13,9 @@ class TestToLookup(unittest.TestCase):
         g1 = b['A']
         g2 = b['B']
         g3 = b['C']
-        self.assert_(isinstance(g1, Grouping))
-        self.assert_(isinstance(g2, Grouping))
-        self.assert_(isinstance(g3, Grouping))
+        self.assertIsInstance(g1, Grouping)
+        self.assertIsInstance(g2, Grouping)
+        self.assertIsInstance(g3, Grouping)
         self.assertEqual(g1.to_list(), ['Agapanthus', 'Allium', 'Alpina', 'Alstroemeria', 'Amaranthus', 'Amarylis'])
         self.assertEqual(g2.to_list(), ['Bouvardia'])
         self.assertEqual(g3.to_list(), ['Carnations', 'Cattleya', 'Celosia', 'Chincherinchee', 'Chrysanthemum'])
@@ -29,11 +29,11 @@ class TestToLookup(unittest.TestCase):
         g3 = b['C']
         g4 = b['D']
         g5 = b['E']
-        self.assert_(isinstance(g1, Grouping))
-        self.assert_(isinstance(g2, Grouping))
-        self.assert_(isinstance(g3, Grouping))
-        self.assert_(isinstance(g4, Grouping))
-        self.assert_(isinstance(g5, Grouping))
+        self.assertIsInstance(g1, Grouping)
+        self.assertIsInstance(g2, Grouping)
+        self.assertIsInstance(g3, Grouping)
+        self.assertIsInstance(g4, Grouping)
+        self.assertIsInstance(g5, Grouping)
         self.assertEqual(g1.to_list(), ['Aardvark'])
         self.assertEqual(g2.to_list(), ['Balloon'])
         self.assertEqual(g3.to_list(), ['Carrot'])
@@ -53,11 +53,11 @@ class TestToLookup(unittest.TestCase):
         g3 = b['Carrot']
         g4 = b['Daisy']
         g5 = b['Ecological']
-        self.assert_(isinstance(g1, Grouping))
-        self.assert_(isinstance(g2, Grouping))
-        self.assert_(isinstance(g3, Grouping))
-        self.assert_(isinstance(g4, Grouping))
-        self.assert_(isinstance(g5, Grouping))
+        self.assertIsInstance(g1, Grouping)
+        self.assertIsInstance(g2, Grouping)
+        self.assertIsInstance(g3, Grouping)
+        self.assertIsInstance(g4, Grouping)
+        self.assertIsInstance(g5, Grouping)
         self.assertEqual(g1.to_list(), [8])
         self.assertEqual(g2.to_list(), [7])
         self.assertEqual(g3.to_list(), [6])
@@ -77,11 +77,11 @@ class TestToLookup(unittest.TestCase):
         g3 = b['C']
         g4 = b['D']
         g5 = b['E']
-        self.assert_(isinstance(g1, Grouping))
-        self.assert_(isinstance(g2, Grouping))
-        self.assert_(isinstance(g3, Grouping))
-        self.assert_(isinstance(g4, Grouping))
-        self.assert_(isinstance(g5, Grouping))
+        self.assertIsInstance(g1, Grouping)
+        self.assertIsInstance(g2, Grouping)
+        self.assertIsInstance(g3, Grouping)
+        self.assertIsInstance(g4, Grouping)
+        self.assertIsInstance(g5, Grouping)
         self.assertEqual(g1.to_list(), ['Aardvark'])
         self.assertEqual(g2.to_list(), ['Balloon', 'Baboon'])
         self.assertEqual(g3.to_list(), ['Carrot'])


### PR DESCRIPTION
The `TestCase.assert_()` method is apparently deprecated in 3.5 (and possibly earlier). I haven't tested this change in anything by 3.5, but `assertIsInstance` is in 2.7 so I assume this will all work.